### PR TITLE
Shrink docker image with multi-stage build

### DIFF
--- a/docker/speedtest/Dockerfile
+++ b/docker/speedtest/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:10-slim AS build-stage
+FROM debian:10-slim AS get-speedtest
 
 RUN apt-get update && apt-get install gnupg1 apt-transport-https dirmngr lsb-release -y
 RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 379CE192D401AB61
@@ -6,7 +6,14 @@ RUN echo "deb https://ookla.bintray.com/debian $(lsb_release -sc) main" | tee  /
 RUN apt-get update
 RUN apt-get install speedtest
 
-FROM node:12-alpine AS prod-stage
+FROM alpine as install-dependencies
+RUN apk add --no-cache npm
+WORKDIR /build
+COPY contents .
+RUN npm ci
+
+FROM alpine as prod-stage
+RUN apk add --no-cache nodejs
 LABEL maintainer="Jonas Friedmann <j@frd.mn>"
 
 WORKDIR /usr/src/app
@@ -16,8 +23,7 @@ ENV INFLUXDB_DB="speedtest" \
     SPEEDTEST_HOST="local" \
     SPEEDTEST_INTERVAL=3600
 
-COPY --from=build-stage /usr/bin/speedtest /usr/bin/speedtest
-COPY contents .
-RUN npm ci
-
 CMD [ "node", "index.js" ]
+
+COPY --from=get-speedtest /usr/bin/speedtest /usr/bin/speedtest
+COPY --from=install-dependencies /build .

--- a/docker/speedtest/Dockerfile
+++ b/docker/speedtest/Dockerfile
@@ -1,5 +1,13 @@
-FROM node:12
-MAINTAINER Jonas Friedmann <j@frd.mn>
+FROM debian:10-slim AS build-stage
+
+RUN apt-get update && apt-get install gnupg1 apt-transport-https dirmngr lsb-release -y
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 379CE192D401AB61
+RUN echo "deb https://ookla.bintray.com/debian $(lsb_release -sc) main" | tee  /etc/apt/sources.list.d/speedtest.list
+RUN apt-get update
+RUN apt-get install speedtest
+
+FROM node:12-alpine AS prod-stage
+LABEL maintainer="Jonas Friedmann <j@frd.mn>"
 
 WORKDIR /usr/src/app
 
@@ -8,13 +16,7 @@ ENV INFLUXDB_DB="speedtest" \
     SPEEDTEST_HOST="local" \
     SPEEDTEST_INTERVAL=3600
 
-RUN apt-get update && apt-get install gnupg1 apt-transport-https dirmngr lsb-core software-properties-common -y
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 379CE192D401AB61
-RUN add-apt-repository "deb https://ookla.bintray.com/debian $(lsb_release -sc) main"
-RUN apt-get update
-RUN apt-get install speedtest
-
-
+COPY --from=build-stage /usr/bin/speedtest /usr/bin/speedtest
 COPY contents .
 RUN npm ci
 


### PR DESCRIPTION
Shrink the docker image with a multi-stage build from 1.14GB to 90.9MB.

```
λ docker images                  
REPOSITORY                   TAG                 IMAGE ID            CREATED             SIZE
speedtest-new                latest              aa7f4dfd39de        4 seconds ago       90.9MB
speedtest-old                latest              950d7e4d82bf        21 seconds ago      1.14GB
```